### PR TITLE
read_csv() float precision.

### DIFF
--- a/ndcsv/read.py
+++ b/ndcsv/read.py
@@ -137,7 +137,8 @@ def _buf_to_xarray(buf):
         if len(rows) == 1 and len(rows[0]) == 1:
             # 0-dimensional file
             # Let pandas.read_csv() apply its magic type detection
-            df = pandas.read_csv(io.StringIO(rows[0][0]), header=None)
+            df = pandas.read_csv(io.StringIO(rows[0][0]), header=None,
+                                 float_precision='high')
             return xarray.DataArray(df.iloc[0, 0])
         else:
             raise ValueError("Malformed N-dimensional CSV")
@@ -155,7 +156,8 @@ def _buf_to_xarray(buf):
     # passed a header
     if len(header) == 1 and len(indexes) > 0:
         df = pandas.read_csv(buf, index_col=index_col, header=None,
-                             low_memory=False, skiprows=2)
+                             low_memory=False, skiprows=2,
+                             float_precision='high')
         df.index.names = indexes
         df.columns = columns[num_index_col:]
         df.columns.names = [columns[0]]
@@ -164,7 +166,7 @@ def _buf_to_xarray(buf):
         if len(header) == 1:
             header = header[0]
         df = pandas.read_csv(buf, index_col=index_col, header=header,
-                             low_memory=False)
+                             low_memory=False, float_precision='high')
 
     if len(indexes) == 0:
         # If originally a Series, squeeze empty df dim

--- a/ndcsv/tests/test_pandas.py
+++ b/ndcsv/tests/test_pandas.py
@@ -12,7 +12,7 @@ def test_write_dataframe():
     buf = io.StringIO()
     write_csv(a, buf)
     print(buf.getvalue())
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
 
     # add index/columns labels
     a.index = ['i1', 'i2']
@@ -23,7 +23,7 @@ def test_write_dataframe():
            "i2,4,5,6\n")
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
 
     # add index/columns names
     a.index.name = 'r'
@@ -35,7 +35,7 @@ def test_write_dataframe():
     buf = io.StringIO()
     write_csv(a, buf)
     print(buf.getvalue())
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
 
 
 def test_write_series():
@@ -46,7 +46,7 @@ def test_write_series():
     buf = io.StringIO()
     write_csv(a, buf)
     print(buf.getvalue())
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
 
     # add index labels
     a.index = ['i1', 'i2']
@@ -56,7 +56,7 @@ def test_write_series():
     buf = io.StringIO()
     write_csv(a, buf)
     print(buf.getvalue())
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
 
     # add index/columns names
     a.index.name = 'r'
@@ -66,4 +66,4 @@ def test_write_series():
     buf = io.StringIO()
     write_csv(a, buf)
     print(buf.getvalue())
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt

--- a/ndcsv/tests/test_precision.py
+++ b/ndcsv/tests/test_precision.py
@@ -62,4 +62,3 @@ def test_precision():
     buf.seek(0)
     b = read_csv(buf)
     xarray.testing.assert_equal(a, b)
-

--- a/ndcsv/tests/test_precision.py
+++ b/ndcsv/tests/test_precision.py
@@ -1,0 +1,65 @@
+"""Test general use case:
+Test precision edge case and provide context manger
+`patch_pandas_read_csv_assert_float_precision_high`
+"""
+import contextlib
+import io
+import sys
+
+import xarray
+
+from ndcsv import write_csv, read_csv
+
+
+@contextlib.contextmanager
+def patch_pandas_read_csv_assert_float_precision_high(func):
+    """Context manager that on-the-fly patch in `pandas.read_csv` with a
+    substitute which check if the arguments contain float_precision='high'
+    before invoking the original `pandas.read_csv`.  Restore the original
+    `pandas.read_csv` on exit context management block.
+
+    Usage, instead of:
+
+        some_code
+        return_value = ndcsv.read_csv(...)
+        some_more_code
+
+    Do this:
+
+        some_code
+        with patch_pandas_read_csv_assert_float_precision_high(ndcsv.read_csv):
+            return_value = ndcsv.read_csv(...)
+        some_more_code
+
+    Note: that this context manager function could have been written as a
+    decorator to the test case functions.  However, as some test cases are
+    decorated with `pytest.mark.parametrize`, which insist certain positional
+    arguments to be named by certain names.  It is therefore difficult to
+    generalise the argument passing, so here we resort to a context manager
+    that is just to wrap around ``
+    """
+    original_pandas_read_csv = sys.modules['pandas'].read_csv
+
+    def substitute_pandas_read_csv(*args, **kwargs):
+
+        assert 'float_precision' in kwargs
+        assert kwargs['float_precision'] == 'high'
+        return original_pandas_read_csv(*args, **kwargs)
+
+    try:
+        sys.modules['pandas'].read_csv = substitute_pandas_read_csv
+        yield func
+    finally:
+        sys.modules['pandas'].read_csv = original_pandas_read_csv
+
+
+def test_precision():
+    a = xarray.DataArray(0.99988)
+
+    buf = io.StringIO()
+    write_csv(a, buf)
+    assert buf.getvalue() == '0.99988\n'
+    buf.seek(0)
+    b = read_csv(buf)
+    xarray.testing.assert_equal(a, b)
+

--- a/ndcsv/tests/test_roundtrip.py
+++ b/ndcsv/tests/test_roundtrip.py
@@ -38,7 +38,7 @@ def test_0d(data, txt):
     a = xarray.DataArray(data)
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     with patch_pandas_read_csv_assert_float_precision_high(read_csv):
         b = read_csv(buf)
@@ -69,7 +69,7 @@ def test_1d(data, txt):
     a = xarray.DataArray(data, dims=['x'], coords={'x': ['x1', 'x2']})
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     with patch_pandas_read_csv_assert_float_precision_high(read_csv):
         b = read_csv(buf)
@@ -90,7 +90,7 @@ def test_1d_multiindex():
 
     buf = io.StringIO()
     write_csv(b, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     with patch_pandas_read_csv_assert_float_precision_high(read_csv):
         c = read_csv(buf)
@@ -140,7 +140,7 @@ def test_2d(data, txt):
                          coords={'r': ['r1', 'r2'], 'c': ['c1', 'c2']})
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     with patch_pandas_read_csv_assert_float_precision_high(read_csv):
         b = read_csv(buf)
@@ -172,7 +172,7 @@ def test_2d_multiindex_cols(explicit_stack):
     else:
         write_csv(a, buf)
 
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     with patch_pandas_read_csv_assert_float_precision_high(read_csv):
         c = read_csv(buf)
@@ -209,7 +209,7 @@ def test_2d_multiindex_rows():
 
     buf = io.StringIO()
     write_csv(b, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     with patch_pandas_read_csv_assert_float_precision_high(read_csv):
         c = read_csv(buf)
@@ -245,7 +245,7 @@ def test_2d_multiindex_both(explicit_stack):
         write_csv(c, buf)
     else:
         write_csv(b, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     with patch_pandas_read_csv_assert_float_precision_high(read_csv):
         d = read_csv(buf)
@@ -268,7 +268,7 @@ def test_xarray_nocoords():
 
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     with patch_pandas_read_csv_assert_float_precision_high(read_csv):
         c = read_csv(buf)
@@ -309,7 +309,7 @@ def test_nonindex_coords(unstack):
            "20,40,2\n")
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     b = read_csv(buf, unstack=unstack)
     xarray.testing.assert_equal(a, b)
@@ -320,7 +320,7 @@ def test_shape1():
     a = xarray.DataArray([1], dims=['x'], coords={'x': ['x1']})
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == 'x,\nx1,1\n'
+    assert buf.getvalue().replace('\r', '') == 'x,\nx1,1\n'
     buf.seek(0)
     with patch_pandas_read_csv_assert_float_precision_high(read_csv):
         b = read_csv(buf)
@@ -337,7 +337,7 @@ def test_duplicate_index():
 
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     with patch_pandas_read_csv_assert_float_precision_high(read_csv):
         b = read_csv(buf)
@@ -358,7 +358,7 @@ def test_duplicate_index_multiindex():
 
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
 
     with patch_pandas_read_csv_assert_float_precision_high(read_csv):

--- a/ndcsv/tests/test_roundtrip.py
+++ b/ndcsv/tests/test_roundtrip.py
@@ -4,15 +4,23 @@
 2. Verify that the output text buffer matches the format specs
 3. Call read_csv()
 4. Verify that the output xarray.DataArray matches the original array
+
+Enclose all `ndcsv.read_csv()` calls in the context manager
+`patch_pandas_read_csv_assert_float_precision_high`.  This is to check that
+`ndcsv.read_csv` always invoke `pandas.read_csv` with float_precision='high'.
 """
 import io
+
 import numpy as np
 from numpy import nan
 import pandas
 import pytest
 import xarray
-from ndcsv import write_csv, read_csv
 
+from ndcsv.tests.test_precision import (
+    patch_pandas_read_csv_assert_float_precision_high)
+
+from ndcsv import write_csv, read_csv
 
 @pytest.mark.parametrize('data,txt', [
     (5, '5\n'),
@@ -31,7 +39,8 @@ def test_0d(data, txt):
     write_csv(a, buf)
     assert buf.getvalue() == txt
     buf.seek(0)
-    b = read_csv(buf)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        b = read_csv(buf)
     xarray.testing.assert_equal(a, b)
 
 
@@ -61,7 +70,8 @@ def test_1d(data, txt):
     write_csv(a, buf)
     assert buf.getvalue() == txt
     buf.seek(0)
-    b = read_csv(buf)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        b = read_csv(buf)
     xarray.testing.assert_equal(a, b)
 
 
@@ -81,10 +91,12 @@ def test_1d_multiindex():
     write_csv(b, buf)
     assert buf.getvalue() == txt
     buf.seek(0)
-    c = read_csv(buf)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        c = read_csv(buf)
     xarray.testing.assert_equal(c, a)
     buf.seek(0)
-    c = read_csv(buf, unstack=False)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        c = read_csv(buf, unstack=False)
     xarray.testing.assert_equal(c, b)
 
 
@@ -129,7 +141,8 @@ def test_2d(data, txt):
     write_csv(a, buf)
     assert buf.getvalue() == txt
     buf.seek(0)
-    b = read_csv(buf)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        b = read_csv(buf)
     xarray.testing.assert_equal(a, b)
 
 
@@ -160,10 +173,12 @@ def test_2d_multiindex_cols(explicit_stack):
 
     assert buf.getvalue() == txt
     buf.seek(0)
-    c = read_csv(buf)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        c = read_csv(buf)
     xarray.testing.assert_equal(a, c)
     buf.seek(0)
-    c = read_csv(buf, unstack=False)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        c = read_csv(buf, unstack=False)
     xarray.testing.assert_equal(b, c)
 
 
@@ -195,10 +210,12 @@ def test_2d_multiindex_rows():
     write_csv(b, buf)
     assert buf.getvalue() == txt
     buf.seek(0)
-    c = read_csv(buf)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        c = read_csv(buf)
     xarray.testing.assert_equal(a, c)
     buf.seek(0)
-    c = read_csv(buf, unstack=False)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        c = read_csv(buf, unstack=False)
     xarray.testing.assert_equal(b, c)
 
 
@@ -229,10 +246,12 @@ def test_2d_multiindex_both(explicit_stack):
         write_csv(b, buf)
     assert buf.getvalue() == txt
     buf.seek(0)
-    d = read_csv(buf)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        d = read_csv(buf)
     xarray.testing.assert_equal(a, d)
     buf.seek(0)
-    d = read_csv(buf, unstack=False)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        d = read_csv(buf, unstack=False)
     xarray.testing.assert_equal(c, d)
 
 
@@ -250,7 +269,8 @@ def test_xarray_nocoords():
     write_csv(a, buf)
     assert buf.getvalue() == txt
     buf.seek(0)
-    c = read_csv(buf)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        c = read_csv(buf)
     xarray.testing.assert_equal(b, c)
 
 
@@ -264,7 +284,8 @@ def test_numerical_ids1():
     buf = io.StringIO()
     write_csv(a, buf)
     buf.seek(0)
-    b = read_csv(buf)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        b = read_csv(buf)
     xarray.testing.assert_equal(a, b)
 
 
@@ -300,7 +321,8 @@ def test_shape1():
     write_csv(a, buf)
     assert buf.getvalue() == 'x,\nx1,1\n'
     buf.seek(0)
-    b = read_csv(buf)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        b = read_csv(buf)
     xarray.testing.assert_equal(a, b)
 
 
@@ -316,7 +338,8 @@ def test_duplicate_index():
     write_csv(a, buf)
     assert buf.getvalue() == txt
     buf.seek(0)
-    b = read_csv(buf)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        b = read_csv(buf)
     xarray.testing.assert_equal(a, b)
 
 
@@ -337,11 +360,13 @@ def test_duplicate_index_multiindex():
     assert buf.getvalue() == txt
     buf.seek(0)
 
-    b = read_csv(buf, unstack=False)
+    with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+        b = read_csv(buf, unstack=False)
     xarray.testing.assert_equal(a, b)
 
     buf.seek(0)
     with pytest.raises(ValueError) as e:
-        read_csv(buf, unstack=True)
+        with patch_pandas_read_csv_assert_float_precision_high(read_csv):
+            read_csv(buf, unstack=True)
     assert str(e.value) == ("cannot reindex or align along dimension 'dim_0' "
                             "because the index has duplicate values")

--- a/ndcsv/tests/test_roundtrip.py
+++ b/ndcsv/tests/test_roundtrip.py
@@ -22,6 +22,7 @@ from ndcsv.tests.test_precision import (
 
 from ndcsv import write_csv, read_csv
 
+
 @pytest.mark.parametrize('data,txt', [
     (5, '5\n'),
     (5.2, '5.2\n'),


### PR DESCRIPTION
read_csv() float precision.

Added new test_precision.py to (1) capture example case 0.99988 and (2) provide a patch context manager that on-the-fly patch pandas.read_csv so that it assert the float_precision='high' is in the arguments.

Modified all test cases in test_read.py and test_roundtrip.py (which should cover all ndcsv.read_csv() use case) so that they use the patch context manager before calling ndcsv.read_csv()