### PR TITLE
Strip '\r' before comparison (for windows compat.)

### DIFF
--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -8,6 +8,8 @@ What's New
 v1.1.0 (Unreleased)
 -------------------
 
+- Fixed unit tests on Windows vs. pandas-0.24 `Jacob Lin`_
+
 
 .. _whats-new.1.0.0:
 
@@ -15,4 +17,8 @@ v1.0.0 (2019-01-02)
 -------------------
 
 - Open sourced and refactored from landg.idealcsv. Rewritten most of the code,
-  unit tests, and documentation. Fixed many bugs.
+  unit tests, and documentation. Fixed many bugs. `Guido Imperiale`_
+
+
+.. _`Guido Imperiale`: https://github.com/crusaderky
+.. _`Jacob Lin`: https://github.com/jcclin

--- a/ndcsv/tests/test_pandas.py
+++ b/ndcsv/tests/test_pandas.py
@@ -12,7 +12,7 @@ def test_write_dataframe():
     buf = io.StringIO()
     write_csv(a, buf)
     print(buf.getvalue())
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
 
     # add index/columns labels
     a.index = ['i1', 'i2']
@@ -23,7 +23,7 @@ def test_write_dataframe():
            "i2,4,5,6\n")
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
 
     # add index/columns names
     a.index.name = 'r'
@@ -35,7 +35,7 @@ def test_write_dataframe():
     buf = io.StringIO()
     write_csv(a, buf)
     print(buf.getvalue())
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
 
 
 def test_write_series():
@@ -46,7 +46,7 @@ def test_write_series():
     buf = io.StringIO()
     write_csv(a, buf)
     print(buf.getvalue())
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
 
     # add index labels
     a.index = ['i1', 'i2']
@@ -56,7 +56,7 @@ def test_write_series():
     buf = io.StringIO()
     write_csv(a, buf)
     print(buf.getvalue())
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
 
     # add index/columns names
     a.index.name = 'r'
@@ -66,4 +66,4 @@ def test_write_series():
     buf = io.StringIO()
     write_csv(a, buf)
     print(buf.getvalue())
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt

--- a/ndcsv/tests/test_roundtrip.py
+++ b/ndcsv/tests/test_roundtrip.py
@@ -29,7 +29,7 @@ def test_0d(data, txt):
     a = xarray.DataArray(data)
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     b = read_csv(buf)
     xarray.testing.assert_equal(a, b)
@@ -59,7 +59,7 @@ def test_1d(data, txt):
     a = xarray.DataArray(data, dims=['x'], coords={'x': ['x1', 'x2']})
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     b = read_csv(buf)
     xarray.testing.assert_equal(a, b)
@@ -79,7 +79,7 @@ def test_1d_multiindex():
 
     buf = io.StringIO()
     write_csv(b, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     c = read_csv(buf)
     xarray.testing.assert_equal(c, a)
@@ -127,7 +127,7 @@ def test_2d(data, txt):
                          coords={'r': ['r1', 'r2'], 'c': ['c1', 'c2']})
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     b = read_csv(buf)
     xarray.testing.assert_equal(a, b)
@@ -158,7 +158,7 @@ def test_2d_multiindex_cols(explicit_stack):
     else:
         write_csv(a, buf)
 
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     c = read_csv(buf)
     xarray.testing.assert_equal(a, c)
@@ -193,7 +193,7 @@ def test_2d_multiindex_rows():
 
     buf = io.StringIO()
     write_csv(b, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     c = read_csv(buf)
     xarray.testing.assert_equal(a, c)
@@ -227,7 +227,7 @@ def test_2d_multiindex_both(explicit_stack):
         write_csv(c, buf)
     else:
         write_csv(b, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     d = read_csv(buf)
     xarray.testing.assert_equal(a, d)
@@ -248,7 +248,7 @@ def test_xarray_nocoords():
 
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     c = read_csv(buf)
     xarray.testing.assert_equal(b, c)
@@ -287,7 +287,7 @@ def test_nonindex_coords(unstack):
            "20,40,2\n")
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     b = read_csv(buf, unstack=unstack)
     xarray.testing.assert_equal(a, b)
@@ -298,7 +298,7 @@ def test_shape1():
     a = xarray.DataArray([1], dims=['x'], coords={'x': ['x1']})
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == 'x,\nx1,1\n'
+    assert buf.getvalue().replace('\r', '') == 'x,\nx1,1\n'
     buf.seek(0)
     b = read_csv(buf)
     xarray.testing.assert_equal(a, b)
@@ -314,7 +314,7 @@ def test_duplicate_index():
 
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
     b = read_csv(buf)
     xarray.testing.assert_equal(a, b)
@@ -334,7 +334,7 @@ def test_duplicate_index_multiindex():
 
     buf = io.StringIO()
     write_csv(a, buf)
-    assert buf.getvalue() == txt
+    assert buf.getvalue().replace('\r', '') == txt
     buf.seek(0)
 
     b = read_csv(buf, unstack=False)


### PR DESCRIPTION
Correct the test failure on windows after pandas >= 0.24
Strip '\r' from line ending to maintain tests compatibility on both windows and unix.