### PR TITLE
Require Python >=3.8; no setuptools

### DIFF
--- a/.github/workflows/pytest-minimal.yml
+++ b/.github/workflows/pytest-minimal.yml
@@ -26,7 +26,7 @@ jobs:
           miniforge-version: latest
           condarc-file: ci/condarc
           use-mamba: true
-          python-version: 3.7
+          python-version: 3.8
           environment-file: ci/requirements-minimal.yml
           activate-environment: ndcsv-minimal
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__
 *.so
 
 # Packages
+.eggs/
 *.egg
 *.egg-info
 dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  -   repo: https://github.com/MarcoGorelli/absolufy-imports
+      rev: v0.3.1
+      hooks:
+      - id: absolufy-imports
+        name: absolufy-imports
   -   repo: https://github.com/pycqa/isort
       rev: 5.10.1
       hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,34 +5,29 @@ repos:
       - id: isort
         language_version: python3
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
         args:
-          - --py37-plus
+          - --py38-plus
   -   repo: https://github.com/psf/black
-      rev: 21.11b1
+      rev: 22.1.0
       hooks:
       - id: black
         language_version: python3
         exclude: versioneer.py
         args:
-          - --target-version=py37
+          - --target-version=py38
   -   repo: https://gitlab.com/pycqa/flake8
       rev: 4.0.1
       hooks:
       - id: flake8
         language_version: python3
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v0.942
     hooks:
       - id: mypy
         additional_dependencies:
-          # Type stubs
-          - types-pkg_resources
-          - types-setuptools
-          # Libraries exclusively imported under `if TYPE_CHECKING:`
-          - typing_extensions  # To be reviewed after dropping Python 3.7
           # Typed libraries
           - numpy
           - pandas

--- a/ci/requirements-docs.yml
+++ b/ci/requirements-docs.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - sphinx=3
+  - sphinx=4
   - sphinx_rtd_theme
   - numpy
   - pandas

--- a/ci/requirements-minimal.yml
+++ b/ci/requirements-minimal.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7
+  - python=3.8
   - pytest
   - coverage
   - numpy=1.14

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -6,7 +6,7 @@ Installation
 Required dependencies
 ---------------------
 
-- Python 3.7 or later
+- Python 3.8 or later
 - `xarray <http://xarray.pydata.org/>`_
 - `pshell <https://pshell.readthedocs.io/>`_
 

--- a/doc/whats-new.rst
+++ b/doc/whats-new.rst
@@ -13,7 +13,7 @@ v1.1.0 (Unreleased)
   ========== ====== =====
   Dependency 1.0.0  1.1.0
   ========== ====== =====
-  python     3.6    3.7
+  python     3.6    3.8
   numpy      1.13   1.14
   pandas     0.21   0.24
   xarray     0.10.9 0.14

--- a/ndcsv/__init__.py
+++ b/ndcsv/__init__.py
@@ -1,7 +1,7 @@
 import importlib.metadata
 
-from .read import read_csv
-from .write import write_csv
+from ndcsv.read import read_csv
+from ndcsv.write import write_csv
 
 try:
     __version__ = importlib.metadata.version("ndcsv")

--- a/ndcsv/__init__.py
+++ b/ndcsv/__init__.py
@@ -1,12 +1,12 @@
-import pkg_resources
+import importlib.metadata
 
 from .read import read_csv
 from .write import write_csv
 
 try:
-    __version__ = pkg_resources.get_distribution("ndcsv").version
-except Exception:  # pragma: nocover
-    # Local copy, not installed with setuptools
+    __version__ = importlib.metadata.version("ndcsv")
+except importlib.metadata.PackageNotFoundError:  # pragma: nocover
+    # Local copy, not installed with pip
     __version__ = "999"
 
 __all__ = ("__version__", "read_csv", "write_csv")

--- a/ndcsv/read.py
+++ b/ndcsv/read.py
@@ -14,7 +14,7 @@ import pandas
 import pshell as sh
 from xarray import DataArray
 
-from .proper_unstack import proper_unstack
+from ndcsv.proper_unstack import proper_unstack
 
 
 def read_csv(path_or_buf: str | TextIO, unstack: bool = True) -> DataArray:

--- a/ndcsv/write.py
+++ b/ndcsv/write.py
@@ -12,7 +12,7 @@ import pandas
 import pshell as sh
 import xarray
 
-from .proper_unstack import proper_unstack
+from ndcsv.proper_unstack import proper_unstack
 
 
 def write_csv(

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Intended Audience :: Science/Research
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -27,9 +26,8 @@ classifiers =
 packages = ndcsv
 zip_safe = False  # https://mypy.readthedocs.io/en/latest/installed_packages.html
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
-    setuptools  # For pkg_resources
     numpy >= 1.14
     pandas >= 0.24
     pshell >= 1.0


### PR DESCRIPTION
- Drop support for Python 3.7
- Remove requirement for setuptools at runtime
- Enforce absolufy_imports in CI
- Upgrade to Sphinx 4